### PR TITLE
Expose all core prettier options in Atom config

### DIFF
--- a/lib/prettier.js
+++ b/lib/prettier.js
@@ -7,6 +7,14 @@ var prettier = require("prettier");
 module.exports = {
   style: null,
   fileTypes: [ ".js", ".jsx" ],
+  prettierCoreOptions: [
+    "printWidth",
+    "tabWidth",
+    "useFlowParser",
+    "singleQuote",
+    "trailingComma",
+    "bracketSpacing"
+  ],
   fileSupported: function(file) {
     // Ensure file is a supported file type.
     var ext = path.extname(file);
@@ -45,10 +53,15 @@ module.exports = {
     var text = selectedText || editor.getText();
     var cursorPosition = editor.getCursorScreenPosition();
 
+    var formatOptions = {};
+    this.prettierCoreOptions.forEach(function(option) {
+      formatOptions[option] = typeof options[option] !== "undefined"
+        ? options[option]
+        : atom.config.get("prettier-atom." + option);
+    });
+
     try {
-      var transformed = prettier.format(text, {
-        printWidth: options.printWidth
-      });
+      var transformed = prettier.format(text, formatOptions);
     } catch (e) {
       console.log("Error transforming using prettier:", e);
       transformed = text;
@@ -93,7 +106,7 @@ module.exports = {
       }.bind(this)
     );
     // Uncomment this to format on resize. Not ready yet. :)
-    // 
+    //
     // if (editor.editorElement) {
     //   window.addEventListener("resize", e => {
     //     const { width } = window.document.body.getBoundingClientRect();
@@ -105,5 +118,13 @@ module.exports = {
     //   });
     // }
   },
-  config: { formatOnSave: { type: "boolean", default: false } }
+  config: {
+    formatOnSave: { type: "boolean", default: false, order: 1 },
+    printWidth: { type: "integer", default: 80, order: 2 },
+    tabWidth: { type: "integer", default: 2, order: 3 },
+    singleQuote: { type: "boolean", default: false, order: 4 },
+    trailingComma: { type: "boolean", default: false, order: 5 },
+    bracketSpacing: { type: "boolean", default: true, order: 6 },
+    useFlowParser: { type: "boolean", default: false, order: 7 }
+  }
 };


### PR DESCRIPTION
Exposes the [core prettier api options](https://github.com/jlongster/prettier#api) as configuration options in the Atom package.

![image](https://cloud.githubusercontent.com/assets/875591/21817354/7b8ef2b2-d718-11e6-9912-4ba9eb0cefd4.png)

Fixes #4