### PR TITLE
Update options in README to reflect current menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,27 @@ Automatically format your Javascript file on save by enabling the *Format On Sav
 #### formatOnSave (default: false)
 
 Format Javascript files when saving.
+
+#### Print Width (default: 80)
+
+Fit code within this line limit
+
+#### Tab Width (default: 2)
+
+Number of spaces it should use per tab
+
+#### Single Quote (default: false)
+
+If true, will use single instead of double quotes
+
+#### Trailing Comma (default: false)
+
+Controls the printing of trailing commas wherever possible
+
+### Bracket Spacing (default: true)
+
+Controls the printing of spaces inside array and objects
+
+#### Use Flow Parser (default: false)
+
+Use the [flow](https://github.com/facebook/flow) parser instead of [babylon](https://github.com/babel/babylon).


### PR DESCRIPTION
The descriptions are from the prettier README. We could, alternatively, just tell people to reference that instead of merging this?