### PR TITLE
Remove unsupported file type warning

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -41,7 +41,6 @@ const format = (event, options = { ignoreSelection: false }) => {
   const isTransformingFile = options.ignoreSelection || !selectedText;
 
   if (isTransformingFile && !isFileTypeSupported(editor.getPath())) {
-    atom.notifications.addWarning('prettier-atom: File type not supported');
     return;
   }
 


### PR DESCRIPTION
The unsupported file type warning doesn't seem necessary, especially if format-on-save is enabled. It's understood that prettier formats JS code, so seeing the unsupported file type warning while editing non-JS code isn't that helpful. It gets a bit spammy.