### PR TITLE
Fix error due to editor.getPath() returning undefined

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -37,10 +37,11 @@ const format = (event, options = { ignoreSelection: false }) => {
   const editor = atom.workspace.getActiveTextEditor();
   if (!editor) return;
 
+  const path = editor.getPath(); // NOTE: may be undefined in certain cases like a new tab
   const selectedText = editor.getSelectedText();
   const isTransformingFile = options.ignoreSelection || !selectedText;
 
-  if (isTransformingFile && !isFileTypeSupported(editor.getPath())) {
+  if (isTransformingFile && path && !isFileTypeSupported(path)) {
     return;
   }
 


### PR DESCRIPTION
Fixes #27 

When opening a new blank document, there is no current path since the user hasn't saved the document to the hard disk yet, so `atom.workspace.getActiveTextEditor().getPath()` can return undefined. Therefore, if the user manually calls prettier via the ctrl+alt+f command and no text is selected, we will try to check that the path is supported, and it will hard error.

This fixes that by just assuming that since the user must be calling the command for this to be the case, that we should go ahead and attempt to do the transform.