### PR TITLE
add ability to transform js embedded in .html or .vue files

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,6 +10,11 @@ const PRETTIER_CORE_OPTIONS = [
   'bracketSpacing',
 ];
 
+const EMBEDDED_SCOPE = [
+  'text.html.vue',
+  'text.html.basic',
+];
+
 // helpers
 const getConfigOption = key => atom.config.get(`prettier-atom.${key}`);
 
@@ -31,6 +36,17 @@ const executePrettier = (text, formatOptions) => {
   }
 };
 
+const transformRange = (editor, range) => {
+  const cursorPositionPriorToFormat = editor.getCursorScreenPosition();
+  const textToTransform = editor.getTextInBufferRange(range);
+  const transformed = executePrettier(textToTransform, getFormatOptions());
+  if (!transformed) {
+    return;
+  }
+  editor.setTextInBufferRange(range, transformed);
+  editor.setCursorScreenPosition(cursorPositionPriorToFormat);
+};
+
 // public API
 const format = (event, options = { ignoreSelection: false }) => {
   const editor = atom.workspace.getActiveTextEditor();
@@ -38,51 +54,31 @@ const format = (event, options = { ignoreSelection: false }) => {
     return;
   }
 
-  const cursorPositionPriorToFormat = editor.getCursorScreenPosition();
   const selectedText = editor.getSelectedText();
-  const isTransformingFile = options.ignoreSelection || !selectedText;
+  const bufferRange = editor.getBuffer().getRange();
+  const isEmbedded = EMBEDDED_SCOPE.includes(getCurrentScope());
 
-  const currentScope = getCurrentScope();
-  const isEmbedded = ['text.html.vue', 'text.html.basic'].includes(currentScope);
-  if (isEmbedded) {
-    const re = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi
-    editor.scan(re, iter => {
-      // only transform first match
-      iter.stop();
-
-      // Create new range with start row advanced by 1,
-      // since we cannot use look-behind on variable-length starting
-      // <script ...> tag
-      const { start, end } = iter.range;
-      const range = new iter.range.constructor(
-        [start.row + 1, start.column],
-        end
-      );
-
-      // Transform range
-      const textToTransform = editor.getTextInBufferRange(range);
-      const transformed = executePrettier(textToTransform, getFormatOptions());
-      if (!transformed) {
-        return;
-      }
-      editor.setTextInBufferRange(range, transformed);
-      editor.setCursorScreenPosition(cursorPositionPriorToFormat);
-    })
-  } else {
-    const textToTransform = isTransformingFile ? editor.getText() : selectedText;
-
-    const transformed = executePrettier(textToTransform, getFormatOptions());
-    if (!transformed) {
-      return;
-    }
-
-    if (isTransformingFile) {
-      editor.setText(transformed);
+  if (options.ignoreSelection || !selectedText) {
+    // transform entire file
+    if (isEmbedded) {
+      const re = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi;
+      editor.backwardsScanInBufferRange(re, bufferRange, iter => {
+        // Create new range with start row advanced by 1,
+        // since we cannot use look-behind on variable-length starting
+        // <script ...> tag
+        const { start, end } = iter.range;
+        const startModified = [start.row + 1, start.column];
+        const range = new iter.range.constructor(startModified, end);
+        transformRange(editor, range);
+      });
     } else {
-      editor.setTextInBufferRange(editor.getSelectedBufferRange(), transformed);
+      transformRange(editor, bufferRange);
     }
-
-    editor.setCursorScreenPosition(cursorPositionPriorToFormat);
+  } else {
+    // transform selected ranges
+    editor.getSelectedBufferRanges().forEach(range => {
+      transformRange(editor, range);
+    });
   }
 };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -42,20 +42,48 @@ const format = (event, options = { ignoreSelection: false }) => {
   const selectedText = editor.getSelectedText();
   const isTransformingFile = options.ignoreSelection || !selectedText;
 
-  const textToTransform = isTransformingFile ? editor.getText() : selectedText;
+  const currentScope = getCurrentScope();
+  const isEmbedded = ['text.html.vue', 'text.html.basic'].includes(currentScope);
+  if (isEmbedded) {
+    const re = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi
+    editor.scan(re, iter => {
+      // only transform first match
+      iter.stop();
 
-  const transformed = executePrettier(textToTransform, getFormatOptions());
-  if (!transformed) {
-    return;
-  }
+      // Create new range with start row advanced by 1,
+      // since we cannot use look-behind on variable-length starting
+      // <script ...> tag
+      const { start, end } = iter.range;
+      const range = new iter.range.constructor(
+        [start.row + 1, start.column],
+        end
+      );
 
-  if (isTransformingFile) {
-    editor.setText(transformed);
+      // Transform range
+      const textToTransform = editor.getTextInBufferRange(range);
+      const transformed = executePrettier(textToTransform, getFormatOptions());
+      if (!transformed) {
+        return;
+      }
+      editor.setTextInBufferRange(range, transformed);
+      editor.setCursorScreenPosition(cursorPositionPriorToFormat);
+    })
   } else {
-    editor.setTextInBufferRange(editor.getSelectedBufferRange(), transformed);
-  }
+    const textToTransform = isTransformingFile ? editor.getText() : selectedText;
 
-  editor.setCursorScreenPosition(cursorPositionPriorToFormat);
+    const transformed = executePrettier(textToTransform, getFormatOptions());
+    if (!transformed) {
+      return;
+    }
+
+    if (isTransformingFile) {
+      editor.setText(transformed);
+    } else {
+      editor.setTextInBufferRange(editor.getSelectedBufferRange(), transformed);
+    }
+
+    editor.setCursorScreenPosition(cursorPositionPriorToFormat);
+  }
 };
 
 const formatOnSaveIfEnabled = () => {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,9 @@
         "source.jsx",
         "source.js.jsx",
         "source.babel",
-        "source.js-semantic"
+        "source.js-semantic",
+        "text.html.basic",
+        "text.html.vue"
       ],
       "items": {
         "type": "string"


### PR DESCRIPTION
For JS embedded within a `<script>` tag in .html or .vue files, selecting the text and transforming currently works well, but it would be nice if this were easier. I've added `text.html.basic` and `text.html.vue` to the allowed scopes, and for these scopes, added the ability to transform the text only within the `<script>` tag.