### PR TITLE
Update to use proper options for 0.17.1 of Prettier

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,10 +4,11 @@ const prettier = require('prettier');
 const PRETTIER_CORE_OPTIONS = [
   'printWidth',
   'tabWidth',
-  'useFlowParser',
+  'parser',
   'singleQuote',
   'trailingComma',
   'bracketSpacing',
+  'jsxBracketSameLine',
 ];
 
 const EMBEDDED_SCOPE = [ 'text.html.vue', 'text.html.basic' ];

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     },
     "jsxBracketSameLine": {
       "title": "JSX Bracket Same Line",
-      "description": "Put > on the last line in JSX",
+      "description": "Put > on the same line in JSX",
       "type": "boolean",
       "default": false,
       "order": 8

--- a/package.json
+++ b/package.json
@@ -100,12 +100,20 @@
       "default": true,
       "order": 7
     },
-    "useFlowParser": {
-      "title": "Use Flow Parser",
-      "description": "Use the [flow](https://github.com/facebook/flow) parser instead of [babylon](https://github.com/babel/babylon).",
+    "jsxBracketSameLine": {
+      "title": "JSX Bracket Same Line",
+      "description": "Put > on the last line in JSX",
       "type": "boolean",
       "default": false,
       "order": 8
+    },
+    "parser": {
+      "title": "Parser",
+      "description": "Use either the [flow](https://github.com/facebook/flow) or [babylon](https://github.com/babel/babylon) parser.",
+      "type": "string",
+      "default": "babylon",
+      "enum": ["babylon", "flow"],
+      "order": 9
     },
     "formatOnSaveScopes": {
       "title": "Format-on-Save Scopes",
@@ -123,7 +131,7 @@
       "items": {
         "type": "string"
       },
-      "order": 9
+      "order": 10
     }
   }
 }


### PR DESCRIPTION
Changes "useFlowParser" to "parser" (now a string enum), and adds "jsxBracketSameLine".