### PR TITLE
BUG FIX: `formatOnSaveSilentError` option is opposite for what it supposed to be

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -98,7 +98,7 @@ const formatOnSaveIfEnabled = () => {
 
   format(null, {
     ignoreSelection: true,
-    ignoreErrors: !getConfigOption('formatOnSaveSilentError'),
+    ignoreErrors: Boolean(getConfigOption('formatOnSaveSilentError')),
   });
 };
 


### PR DESCRIPTION
Hey, I've little mess up with #46 
This is a bug fix