### PR TITLE
Update to Prettier 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "find-root": "^0.1.1",
-    "prettier": "^0.18.0"
+    "prettier": "^0.19.0"
   },
   "devDependencies": {
     "eslint": "^3.6.0",
@@ -97,8 +97,13 @@
     "trailingComma": {
       "title": "Trailing Comma",
       "description": "Controls the printing of trailing commas wherever possible",
-      "type": "boolean",
-      "default": false,
+      "type": "string",
+      "default": "none",
+      "enum": [
+        "none",
+        "es5",
+        "all"
+      ],
       "order": 6
     },
     "bracketSpacing": {


### PR DESCRIPTION
Updates Prettier dep to 0.19.0, and changes trailingComma option to enum.