### PR TITLE
feat($linter-eslint): Warn about linter-eslint "Format on Save"

### DIFF
--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -105,6 +105,10 @@ var shouldRespectEslintignore = function shouldRespectEslintignore() {
   return getConfigOption('formatOnSaveOptions.respectEslintignore');
 };
 
+var isLinterEslintAutofixEnabled = function isLinterEslintAutofixEnabled() {
+  return atom.config.get('linter-eslint.fixOnSave');
+};
+
 var getPrettierOptions = function getPrettierOptions(editor) {
   return {
     printWidth: getPrettierOption('printWidth'),
@@ -126,6 +130,7 @@ module.exports = {
   isCurrentScopeEmbeddedScope: isCurrentScopeEmbeddedScope,
   isFilePathEslintignored: isFilePathEslintignored,
   isFormatOnSaveEnabled: isFormatOnSaveEnabled,
+  isLinterEslintAutofixEnabled: isLinterEslintAutofixEnabled,
   shouldUseEslint: shouldUseEslint,
   shouldRespectEslintignore: shouldRespectEslintignore,
   getPrettierOptions: getPrettierOptions

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,12 +1,19 @@
 'use strict';
 
 var config = require('./config-schema.json');
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
+
+var _require = require('atom'),
+    CompositeDisposable = _require.CompositeDisposable;
 
 // local helpers
+
+
 var commands = null;
 var editorObserver = null;
 var format = null;
 var formatOnSave = null;
+var warnAboutLinterEslintFixOnSave = null;
 
 // HACK: lazy load most of the code we need for performance
 var lazyFormat = function lazyFormat() {
@@ -24,25 +31,44 @@ var lazyFormatOnSave = function lazyFormatOnSave() {
   if (editor) formatOnSave(editor);
 };
 
+// HACK: lazy load most of the code we need for performance
+var lazyWarnAboutLinterEslintFixOnSave = function lazyWarnAboutLinterEslintFixOnSave() {
+  if (!warnAboutLinterEslintFixOnSave) {
+    // eslint-disable-next-line global-require
+    warnAboutLinterEslintFixOnSave = require('./warnAboutLinterEslintFixOnSave');
+  }
+  warnAboutLinterEslintFixOnSave();
+};
+
 var setEventHandlers = function setEventHandlers(editor) {
   return editor.getBuffer().onWillSave(function () {
     return lazyFormatOnSave(editor);
   });
 };
 
+var subscriptions = new CompositeDisposable();
+
 // public API
 var activate = function activate() {
   commands = atom.commands.add('atom-workspace', 'prettier:format', lazyFormat);
   editorObserver = atom.workspace.observeTextEditors(setEventHandlers);
+  subscriptions.add(atom.config.observe('linter-eslint.fixOnSave', function () {
+    return lazyWarnAboutLinterEslintFixOnSave();
+  }));
+  subscriptions.add(atom.config.observe('prettier-atom.useEslint', function () {
+    return lazyWarnAboutLinterEslintFixOnSave();
+  }));
 };
 
 var deactivate = function deactivate() {
   if (commands) commands.dispose();
   if (editorObserver) editorObserver.dispose();
+  subscriptions.dispose();
 };
 
 module.exports = {
   activate: activate,
   deactivate: deactivate,
-  config: config
+  config: config,
+  subscriptions: subscriptions
 };

--- a/dist/warnAboutLinterEslintFixOnSave.js
+++ b/dist/warnAboutLinterEslintFixOnSave.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var _require = require('./helpers'),
+    shouldUseEslint = _require.shouldUseEslint,
+    isLinterEslintAutofixEnabled = _require.isLinterEslintAutofixEnabled;
+
+var message = "prettier-atom: linter-eslint's `Fix on Save` feature is currently enabled. " + 'We recommend disabling this feature when using the ESlint integration from prettier-atom';
+
+var options = { dismissable: true };
+
+// $FlowFixMe
+var displayWarning = function displayWarning() {
+  return atom.notifications.addWarning(message, options);
+};
+
+var warnAboutLinterEslintFixOnSave = function warnAboutLinterEslintFixOnSave() {
+  return shouldUseEslint() && isLinterEslintAutofixEnabled() && displayWarning();
+};
+
+module.exports = warnAboutLinterEslintFixOnSave;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -68,6 +68,8 @@ const isFormatOnSaveEnabled = () => getConfigOption('formatOnSaveOptions.enabled
 
 const shouldRespectEslintignore = () => getConfigOption('formatOnSaveOptions.respectEslintignore');
 
+const isLinterEslintAutofixEnabled = () => atom.config.get('linter-eslint.fixOnSave');
+
 const getPrettierOptions = (editor: TextEditor) => ({
   printWidth: getPrettierOption('printWidth'),
   tabWidth: useAtomTabLengthIfAuto(editor, getPrettierOption('tabWidth')),
@@ -87,6 +89,7 @@ module.exports = {
   isCurrentScopeEmbeddedScope,
   isFilePathEslintignored,
   isFormatOnSaveEnabled,
+  isLinterEslintAutofixEnabled,
   shouldUseEslint,
   shouldRespectEslintignore,
   getPrettierOptions,

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -10,6 +10,7 @@ const {
   isInScope,
   isFilePathEslintignored,
   isCurrentScopeEmbeddedScope,
+  isLinterEslintAutofixEnabled,
   shouldUseEslint,
   getPrettierOptions,
 } = require('./helpers');
@@ -90,6 +91,18 @@ describe('isInScope', () => {
 
     expect(mockGetGrammar).toHaveBeenCalled();
     expect(mockGet).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.scopes');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('isLinterEslintAutofixEnabled', () => {
+  test('returns the value from the linter-eslint config', () => {
+    atom = { config: { get: jest.fn(() => true) } };
+
+    const actual = isLinterEslintAutofixEnabled();
+    const expected = true;
+
+    expect(atom.config.get).toHaveBeenCalledWith('linter-eslint.fixOnSave');
     expect(actual).toBe(expected);
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,13 @@
 const config = require('./config-schema.json');
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
+const { CompositeDisposable } = require('atom');
 
 // local helpers
 let commands = null;
 let editorObserver = null;
 let format = null;
 let formatOnSave = null;
+let warnAboutLinterEslintFixOnSave = null;
 
 // HACK: lazy load most of the code we need for performance
 const lazyFormat = () => {
@@ -22,21 +25,40 @@ const lazyFormatOnSave = () => {
   if (editor) formatOnSave(editor);
 };
 
+// HACK: lazy load most of the code we need for performance
+const lazyWarnAboutLinterEslintFixOnSave = () => {
+  if (!warnAboutLinterEslintFixOnSave) {
+    // eslint-disable-next-line global-require
+    warnAboutLinterEslintFixOnSave = require('./warnAboutLinterEslintFixOnSave');
+  }
+  warnAboutLinterEslintFixOnSave();
+};
+
 const setEventHandlers = editor => editor.getBuffer().onWillSave(() => lazyFormatOnSave(editor));
+
+const subscriptions = new CompositeDisposable();
 
 // public API
 const activate = () => {
   commands = atom.commands.add('atom-workspace', 'prettier:format', lazyFormat);
   editorObserver = atom.workspace.observeTextEditors(setEventHandlers);
+  subscriptions.add(
+    atom.config.observe('linter-eslint.fixOnSave', () => lazyWarnAboutLinterEslintFixOnSave()),
+  );
+  subscriptions.add(
+    atom.config.observe('prettier-atom.useEslint', () => lazyWarnAboutLinterEslintFixOnSave()),
+  );
 };
 
 const deactivate = () => {
   if (commands) commands.dispose();
   if (editorObserver) editorObserver.dispose();
+  subscriptions.dispose();
 };
 
 module.exports = {
   activate,
   deactivate,
   config,
+  subscriptions,
 };

--- a/src/warnAboutLinterEslintFixOnSave.js
+++ b/src/warnAboutLinterEslintFixOnSave.js
@@ -1,0 +1,15 @@
+// @flow
+const { shouldUseEslint, isLinterEslintAutofixEnabled } = require('./helpers');
+
+const message = "prettier-atom: linter-eslint's `Fix on Save` feature is currently enabled. " +
+  'We recommend disabling this feature when using the ESlint integration from prettier-atom';
+
+const options = { dismissable: true };
+
+// $FlowFixMe
+const displayWarning = () => atom.notifications.addWarning(message, options);
+
+const warnAboutLinterEslintFixOnSave = () =>
+  shouldUseEslint() && isLinterEslintAutofixEnabled() && displayWarning();
+
+module.exports = warnAboutLinterEslintFixOnSave;

--- a/src/warnAboutLinterEslintFixOnSave.test.js
+++ b/src/warnAboutLinterEslintFixOnSave.test.js
@@ -1,0 +1,40 @@
+// @flow
+const helpers = require('./helpers');
+const warnAboutLinterEslintFixOnSave = require('./warnAboutLinterEslintFixOnSave');
+
+jest.mock('./helpers');
+
+beforeEach(() => {
+  atom = { notifications: { addWarning: jest.fn() } };
+  // $FlowFixMe
+  helpers.isLinterEslintAutofixEnabled.mockImplementation(() => true);
+  // $FlowFixMe
+  helpers.shouldUseEslint.mockImplementation(() => true);
+});
+
+test('it warns about not having eslint autofix on', () => {
+  warnAboutLinterEslintFixOnSave();
+
+  // $FlowFixMe
+  expect(atom.notifications.addWarning).toHaveBeenCalled();
+});
+
+test('it does not warn if eslint autofix is disabled', () => {
+  // $FlowFixMe
+  helpers.isLinterEslintAutofixEnabled.mockImplementation(() => false);
+
+  warnAboutLinterEslintFixOnSave();
+
+  // $FlowFixMe
+  expect(atom.notifications.addWarning).not.toHaveBeenCalled();
+});
+
+test('it does not warn if eslint integration is disabled', () => {
+  // $FlowFixMe
+  helpers.shouldUseEslint.mockImplementation(() => false);
+
+  warnAboutLinterEslintFixOnSave();
+
+  // $FlowFixMe
+  expect(atom.notifications.addWarning).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
If linter-eslint's "Format On Save" feature is enabled at the same time as prettier-atom's ESlint
integration is on, it will be somewhat redundant and may cause errors. Therefore, we warn the user
if both of these options are detected to be on at the same time.