### PR TITLE
fix($formatOnSave): Handle null filePath

### DIFF
--- a/decls/index.js
+++ b/decls/index.js
@@ -17,7 +17,7 @@ declare type TextEditor = {
   getTextInBufferRange: () => string,
   setCursorScreenPosition: (point: Point) => Point,
   setTextInBufferRange: (bufferRange: Range, text: string) => Range,
-  buffer: {file: {path: FilePath}},
+  buffer: {file: {path: ?FilePath}},
   backwardsScanInBufferRange: (
     regex: RegExp,
     Range: Range,

--- a/dist/formatOnSave.js
+++ b/dist/formatOnSave.js
@@ -13,11 +13,11 @@ var _require2 = require('./helpers'),
     isInScope = _require2.isInScope;
 
 var formatOnSaveIfAppropriate = function formatOnSaveIfAppropriate(editor) {
-  var filePath = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : getCurrentFilePath(editor);
+  var filePath = getCurrentFilePath(editor);
 
   if (!isFormatOnSaveEnabled()) return;
   if (!isInScope(editor)) return;
-  if (shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
+  if (filePath && shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
 
   if (isCurrentScopeEmbeddedScope(editor)) {
     executePrettierOnEmbeddedScripts(editor);

--- a/src/formatOnSave.js
+++ b/src/formatOnSave.js
@@ -9,10 +9,12 @@ const {
   isInScope,
 } = require('./helpers');
 
-const formatOnSaveIfAppropriate = (editor: TextEditor, filePath: FilePath = getCurrentFilePath(editor)) => {
+const formatOnSaveIfAppropriate = (editor: TextEditor) => {
+  const filePath = getCurrentFilePath(editor);
+
   if (!isFormatOnSaveEnabled()) return;
   if (!isInScope(editor)) return;
-  if (shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
+  if (filePath && shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
 
   if (isCurrentScopeEmbeddedScope(editor)) {
     executePrettierOnEmbeddedScripts(editor);

--- a/src/formatOnSave.test.js
+++ b/src/formatOnSave.test.js
@@ -67,14 +67,25 @@ test('it does nothing if not a valid scope according to config', () => {
 
 test('it does nothing if config says to respectEslintignore and file is matched by eslintignore', () => {
   // $FlowFixMe
+  helpers.getCurrentFilePath.mockImplementation(() => filePathFixture);
+  // $FlowFixMe
   helpers.shouldRespectEslintignore.mockImplementation(() => true);
   // $FlowFixMe
   helpers.isFilePathEslintignored.mockImplementation(() => true);
 
-  formatOnSave(editor, filePathFixture);
+  formatOnSave(editor);
 
   expect(helpers.shouldRespectEslintignore).toHaveBeenCalled();
   expect(helpers.isFilePathEslintignored).toHaveBeenCalledWith('foo.js');
   expect(executePrettierOnBufferRange).not.toHaveBeenCalled();
   expect(executePrettierOnEmbeddedScripts).not.toHaveBeenCalled();
+});
+
+test('does not attempt to check filePath matches .eslintignore if `currentFilePath` is null', () => {
+  // $FlowFixMe
+  helpers.getCurrentFilePath.mockImplementation(() => null);
+
+  formatOnSave(editor, filePathFixture);
+
+  expect(helpers.shouldRespectEslintignore).not.toHaveBeenCalled();
 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,7 @@ const flow = (func: Function, ...funcs: Array<Function>) =>
 
 const getDirFromFilePath = (filePath: FilePath): FilePath => path.parse(filePath).dir;
 
-const getNearestEslintignorePath = (filePath: FilePath): FilePath =>
+const getNearestEslintignorePath = (filePath: FilePath): ?FilePath =>
   findCached(getDirFromFilePath(filePath), '.eslintignore');
 
 const getFilePathRelativeToEslintignore = (filePath: FilePath): FilePath =>


### PR DESCRIPTION
There may be cases where an editor will return a null filePath (such as when saving a new file).
Previously, doing so would cause an error because we assumed its presence when looking for the
nearest `.eslintignore` file. The solution is to short-circuit this check if the filePath is not
present, since there's no way it can be ignored if it doesn't have a path anyway.

Fixes #67