### PR TITLE
fix(excludedGlobs): Respect excluded globs when formatting on save

### DIFF
--- a/dist/formatOnSave.js
+++ b/dist/formatOnSave.js
@@ -10,6 +10,7 @@ var _require2 = require('./helpers'),
     getCurrentFilePath = _require2.getCurrentFilePath,
     isCurrentScopeEmbeddedScope = _require2.isCurrentScopeEmbeddedScope,
     isFilePathEslintignored = _require2.isFilePathEslintignored,
+    isFilePathExcluded = _require2.isFilePathExcluded,
     isInScope = _require2.isInScope;
 
 var formatOnSaveIfAppropriate = function formatOnSaveIfAppropriate(editor) {
@@ -17,6 +18,7 @@ var formatOnSaveIfAppropriate = function formatOnSaveIfAppropriate(editor) {
 
   if (!isFormatOnSaveEnabled()) return;
   if (!isInScope(editor)) return;
+  if (filePath && isFilePathExcluded(filePath)) return;
   if (filePath && shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
 
   if (isCurrentScopeEmbeddedScope(editor)) {

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -117,6 +117,10 @@ var isLinterEslintAutofixEnabled = function isLinterEslintAutofixEnabled() {
   return atom.config.get('linter-eslint.fixOnSave');
 };
 
+var isFilePathExcluded = function isFilePathExcluded(filePath) {
+  return someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.excludedGlobs'), filePath);
+};
+
 var getPrettierOptions = function getPrettierOptions(editor) {
   return {
     printWidth: getPrettierOption('printWidth'),
@@ -137,6 +141,7 @@ module.exports = {
   isInScope: isInScope,
   isCurrentScopeEmbeddedScope: isCurrentScopeEmbeddedScope,
   isFilePathEslintignored: isFilePathEslintignored,
+  isFilePathExcluded: isFilePathExcluded,
   isFormatOnSaveEnabled: isFormatOnSaveEnabled,
   isLinterEslintAutofixEnabled: isLinterEslintAutofixEnabled,
   shouldUseEslint: shouldUseEslint,

--- a/src/formatOnSave.js
+++ b/src/formatOnSave.js
@@ -6,6 +6,7 @@ const {
   getCurrentFilePath,
   isCurrentScopeEmbeddedScope,
   isFilePathEslintignored,
+  isFilePathExcluded,
   isInScope,
 } = require('./helpers');
 
@@ -14,6 +15,7 @@ const formatOnSaveIfAppropriate = (editor: TextEditor) => {
 
   if (!isFormatOnSaveEnabled()) return;
   if (!isInScope(editor)) return;
+  if (filePath && isFilePathExcluded(filePath)) return;
   if (filePath && shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
 
   if (isCurrentScopeEmbeddedScope(editor)) {

--- a/src/formatOnSave.test.js
+++ b/src/formatOnSave.test.js
@@ -25,6 +25,8 @@ beforeEach(() => {
   helpers.isFilePathEslintignored.mockImplementation(() => false);
   // $FlowFixMe
   helpers.isCurrentScopeEmbeddedScope.mockImplementation(() => false);
+  // $FlowFixMe
+  helpers.getCurrentFilePath.mockImplementation(() => filePathFixture);
   editor.getBuffer.mockImplementation(() => ({ getRange: jest.fn(() => rangeFixture) }));
 });
 
@@ -61,6 +63,17 @@ test('it does nothing if not a valid scope according to config', () => {
   formatOnSave(editor, filePathFixture);
 
   expect(helpers.isInScope).toHaveBeenCalled();
+  expect(executePrettierOnBufferRange).not.toHaveBeenCalled();
+  expect(executePrettierOnEmbeddedScripts).not.toHaveBeenCalled();
+});
+
+test('it does nothing if filePath matches an excluded glob', () => {
+  // $FlowFixMe
+  helpers.isFilePathExcluded.mockImplementation(() => true);
+
+  formatOnSave(editor, filePathFixture);
+
+  expect(helpers.isFilePathExcluded).toHaveBeenCalled();
   expect(executePrettierOnBufferRange).not.toHaveBeenCalled();
   expect(executePrettierOnEmbeddedScripts).not.toHaveBeenCalled();
 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -81,6 +81,9 @@ const shouldRespectEslintignore = () => getConfigOption('formatOnSaveOptions.res
 
 const isLinterEslintAutofixEnabled = () => atom.config.get('linter-eslint.fixOnSave');
 
+const isFilePathExcluded = (filePath: FilePath) =>
+  someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.excludedGlobs'), filePath);
+
 const getPrettierOptions = (editor: TextEditor) => ({
   printWidth: getPrettierOption('printWidth'),
   tabWidth: useAtomTabLengthIfAuto(editor, getPrettierOption('tabWidth')),
@@ -99,6 +102,7 @@ module.exports = {
   isInScope,
   isCurrentScopeEmbeddedScope,
   isFilePathEslintignored,
+  isFilePathExcluded,
   isFormatOnSaveEnabled,
   isLinterEslintAutofixEnabled,
   shouldUseEslint,

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -10,6 +10,7 @@ const {
   getCurrentFilePath,
   isInScope,
   isFilePathEslintignored,
+  isFilePathExcluded,
   isCurrentScopeEmbeddedScope,
   isLinterEslintAutofixEnabled,
   shouldUseEslint,
@@ -172,6 +173,28 @@ describe('isFilePathEslintignored', () => {
       path.join(__dirname, '..', 'tests', 'fixtures'),
       '.eslintignore',
     );
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('isFilePathExcluded', () => {
+  test('returns false if filePath is not listed in the globs', () => {
+    atom = { config: { get: jest.fn(() => []) } };
+
+    const actual = isFilePathExcluded('foo.js');
+    const expected = false;
+
+    expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.excludedGlobs');
+    expect(actual).toBe(expected);
+  });
+
+  test('returns true if filePath is listed in the globs', () => {
+    atom = { config: { get: jest.fn(() => ['*.js']) } };
+
+    const actual = isFilePathExcluded('foo.js');
+    const expected = true;
+
+    expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.excludedGlobs');
     expect(actual).toBe(expected);
   });
 });


### PR DESCRIPTION
During the integration of `prettier-eslint`, somehow the excludedGlobs option never got implemented
in formatOnSave. This has now been added back in.

Fixes #73