### PR TITLE
fix($config): Unset old config options causing errors

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -58,6 +58,8 @@ var activate = function activate() {
   subscriptions.add(atom.config.observe('prettier-atom.useEslint', function () {
     return lazyWarnAboutLinterEslintFixOnSave();
   }));
+  atom.config.unset('prettier-atom.singleQuote');
+  atom.config.unset('prettier-atom.trailingComma');
 };
 
 var deactivate = function deactivate() {

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,11 @@ const activate = () => {
   subscriptions.add(
     atom.config.observe('prettier-atom.useEslint', () => lazyWarnAboutLinterEslintFixOnSave()),
   );
+
+  // HACK: an Atom bug seems to be causing old configuration settings to linger for some users
+  //       https://github.com/jlongster/prettier-atom/issues/72
+  atom.config.unset('prettier-atom.singleQuote');
+  atom.config.unset('prettier-atom.trailingComma');
 };
 
 const deactivate = () => {


### PR DESCRIPTION
It seems that Atom may have a bug that is causing errors for some users. When we moved to a new
config schema, some users still have the old configuration options still set. This is preventing
them from loading prettier in some cases, because the options have incorrect values. It's difficult
to tell what is going on here and this fix may not work.

Fixes #72