### PR TITLE
fix(formatOnSave): don't error when saving a new file

### DIFF
--- a/decls/index.js
+++ b/decls/index.js
@@ -1,23 +1,23 @@
 // types for working with Atom stuff
 declare type FilePath = string;
-declare type Point = {row: number, column: number};
-declare type Range = {start: Point, end: Point};
+declare type Point = { row: number, column: number };
+declare type Range = { start: Point, end: Point };
 declare type Ranges = Array<Range>;
 // eslint-disable-next-line no-undef
 declare type Globs = Array<string>;
 // eslint-disable-next-line no-undef
 declare type TextEditor = {
-  getGrammar: () => {scopeName: string},
-  getBuffer: () => {getRange: () => Range},
+  getGrammar: () => { scopeName: string },
+  getBuffer: () => { getRange: () => Range },
   getCursorScreenPosition: () => Point,
-  getLastCursor: () => {getScopeDescriptor: () => string},
+  getLastCursor: () => { getScopeDescriptor: () => string },
   getSelectedText: () => string,
   getSelectedBufferRanges: () => Ranges,
   // getTextInRange: () => string,
   getTextInBufferRange: () => string,
   setCursorScreenPosition: (point: Point) => Point,
   setTextInBufferRange: (bufferRange: Range, text: string) => Range,
-  buffer: {file: {path: ?FilePath}},
+  buffer: { file: ?{ path: ?FilePath } },
   backwardsScanInBufferRange: (
     regex: RegExp,
     Range: Range,
@@ -28,8 +28,8 @@ declare type TextEditor = {
         range: Range,
         stop: Function,
         replace: (replacement: string) => void,
-      }
-    ) => void
+      },
+    ) => void,
   ) => void,
 };
 declare var atom: {
@@ -37,6 +37,6 @@ declare var atom: {
     get: (key: string) => any,
   },
   notifications: {
-    addError: (message: string, options?: {detail?: string, dismissable?: boolean}) => void,
+    addError: (message: string, options?: { detail?: string, dismissable?: boolean }) => void,
   },
 };

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -82,7 +82,7 @@ var getPrettierOption = function getPrettierOption(key) {
 };
 
 var getCurrentFilePath = function getCurrentFilePath(editor) {
-  return editor.buffer.file.path;
+  return editor.buffer.file ? editor.buffer.file.path : undefined;
 };
 
 var isInScope = function isInScope(editor) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -55,7 +55,7 @@ const shouldDisplayErrors = () => !getConfigOption('silenceErrors');
 
 const getPrettierOption = (key: string) => getConfigOption(`prettierOptions.${key}`);
 
-const getCurrentFilePath = (editor: TextEditor) => editor.buffer.file.path;
+const getCurrentFilePath = (editor: TextEditor) => editor.buffer.file ? editor.buffer.file.path : undefined;
 
 const isInScope = (editor: TextEditor) =>
   getConfigOption('formatOnSaveOptions.scopes').includes(getCurrentScope(editor));

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -67,6 +67,15 @@ describe('getCurrentFilePath', () => {
 
     expect(actual).toBe(expected);
   });
+
+  test('returns undefined if there is no file', () => {
+    const editor = textEditor({ buffer: { file: null } });
+
+    const actual = getCurrentFilePath(editor);
+    const expected = undefined;
+
+    expect(actual).toBe(expected);
+  });
 });
 
 describe('isInScope', () => {


### PR DESCRIPTION
Fixes a bug where saving a brand new file would cause an error. This was because we were trying to
access the path of the editor's buffer's file when the file is actually null. Now we check for the
presence of the file before trying to access its path.

Fixes #79