### PR TITLE
feat(whitelist-globs): add ability to whitelist globs

### DIFF
--- a/dist/config-schema.json
+++ b/dist/config-schema.json
@@ -52,10 +52,17 @@
       },
       "excludedGlobs": {
         "title": "Exclude (list of globs)",
-        "description": "A list of file globs to exclude from formatting on save (takes precedence over scopes). Use commas to seperate each glob",
+        "description": "A list of file globs to exclude from formatting on save (takes precedence over scopes). Use commas to seperate each glob.",
         "type": "array",
         "default": [],
         "order": 4
+      },
+      "whitelistedGlobs": {
+        "title": "Include (list of globs)",
+        "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob.",
+        "type": "array",
+        "default": [],
+        "order": 5
       }
     }
   },

--- a/dist/formatOnSave.js
+++ b/dist/formatOnSave.js
@@ -11,14 +11,18 @@ var _require2 = require('./helpers'),
     isCurrentScopeEmbeddedScope = _require2.isCurrentScopeEmbeddedScope,
     isFilePathEslintignored = _require2.isFilePathEslintignored,
     isFilePathExcluded = _require2.isFilePathExcluded,
-    isInScope = _require2.isInScope;
+    isInScope = _require2.isInScope,
+    isFilePathWhitelisted = _require2.isFilePathWhitelisted;
 
 var formatOnSaveIfAppropriate = function formatOnSaveIfAppropriate(editor) {
   var filePath = getCurrentFilePath(editor);
 
   if (!isFormatOnSaveEnabled()) return;
-  if (!isInScope(editor)) return;
-  if (filePath && isFilePathExcluded(filePath)) return;
+
+  if (filePath && !isFilePathWhitelisted(filePath)) {
+    if (!isInScope(editor)) return;
+    if (filePath && isFilePathExcluded(filePath)) return;
+  }
   if (filePath && shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
 
   if (isCurrentScopeEmbeddedScope(editor)) {

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -121,6 +121,10 @@ var isFilePathExcluded = function isFilePathExcluded(filePath) {
   return someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.excludedGlobs'), filePath);
 };
 
+var isFilePathWhitelisted = function isFilePathWhitelisted(filePath) {
+  return someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.whitelistedGlobs'), filePath);
+};
+
 var getPrettierOptions = function getPrettierOptions(editor) {
   return {
     printWidth: getPrettierOption('printWidth'),
@@ -142,6 +146,7 @@ module.exports = {
   isCurrentScopeEmbeddedScope: isCurrentScopeEmbeddedScope,
   isFilePathEslintignored: isFilePathEslintignored,
   isFilePathExcluded: isFilePathExcluded,
+  isFilePathWhitelisted: isFilePathWhitelisted,
   isFormatOnSaveEnabled: isFormatOnSaveEnabled,
   isLinterEslintAutofixEnabled: isLinterEslintAutofixEnabled,
   shouldUseEslint: shouldUseEslint,

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -52,10 +52,17 @@
       },
       "excludedGlobs": {
         "title": "Exclude (list of globs)",
-        "description": "A list of file globs to exclude from formatting on save (takes precedence over scopes). Use commas to seperate each glob",
+        "description": "A list of file globs to exclude from formatting on save (takes precedence over scopes). Use commas to seperate each glob.",
         "type": "array",
         "default": [],
         "order": 4
+      },
+      "whitelistedGlobs": {
+        "title": "Include (list of globs)",
+        "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob.",
+        "type": "array",
+        "default": [],
+        "order": 5
       }
     }
   },

--- a/src/formatOnSave.js
+++ b/src/formatOnSave.js
@@ -8,14 +8,18 @@ const {
   isFilePathEslintignored,
   isFilePathExcluded,
   isInScope,
+  isFilePathWhitelisted,
 } = require('./helpers');
 
 const formatOnSaveIfAppropriate = (editor: TextEditor) => {
   const filePath = getCurrentFilePath(editor);
 
   if (!isFormatOnSaveEnabled()) return;
-  if (!isInScope(editor)) return;
-  if (filePath && isFilePathExcluded(filePath)) return;
+
+  if (filePath && !isFilePathWhitelisted(filePath)) {
+    if (!isInScope(editor)) return;
+    if (filePath && isFilePathExcluded(filePath)) return;
+  }
   if (filePath && shouldRespectEslintignore() && isFilePathEslintignored(filePath)) return;
 
   if (isCurrentScopeEmbeddedScope(editor)) {

--- a/src/formatOnSave.test.js
+++ b/src/formatOnSave.test.js
@@ -36,6 +36,19 @@ test('it executes prettier on buffer range', () => {
   expect(executePrettierOnBufferRange).toHaveBeenCalledWith(editor, rangeFixture);
 });
 
+test('it executes prettier on buffer range if file is whitelisted regardless of exclusions or scopes', () => {
+  // $FlowFixMe
+  helpers.isInScope.mockImplementation(() => false);
+  // $FlowFixMe
+  helpers.isFilePathExcluded.mockImplementation(() => true);
+  // $FlowFixMe
+  helpers.isFilePathWhitelisted.mockImplementation(() => true);
+
+  formatOnSave(editor, filePathFixture);
+
+  expect(executePrettierOnBufferRange).toHaveBeenCalledWith(editor, rangeFixture);
+});
+
 test('it executes prettier on embedded scripts if scope is an embedded scope', () => {
   // $FlowFixMe
   helpers.isCurrentScopeEmbeddedScope.mockImplementation(() => true);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -84,6 +84,9 @@ const isLinterEslintAutofixEnabled = () => atom.config.get('linter-eslint.fixOnS
 const isFilePathExcluded = (filePath: FilePath) =>
   someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.excludedGlobs'), filePath);
 
+const isFilePathWhitelisted = (filePath: FilePath) =>
+  someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.whitelistedGlobs'), filePath);
+
 const getPrettierOptions = (editor: TextEditor) => ({
   printWidth: getPrettierOption('printWidth'),
   tabWidth: useAtomTabLengthIfAuto(editor, getPrettierOption('tabWidth')),
@@ -103,6 +106,7 @@ module.exports = {
   isCurrentScopeEmbeddedScope,
   isFilePathEslintignored,
   isFilePathExcluded,
+  isFilePathWhitelisted,
   isFormatOnSaveEnabled,
   isLinterEslintAutofixEnabled,
   shouldUseEslint,

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -11,6 +11,7 @@ const {
   isInScope,
   isFilePathEslintignored,
   isFilePathExcluded,
+  isFilePathWhitelisted,
   isCurrentScopeEmbeddedScope,
   isLinterEslintAutofixEnabled,
   shouldUseEslint,
@@ -204,6 +205,28 @@ describe('isFilePathExcluded', () => {
     const expected = true;
 
     expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.excludedGlobs');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('isFilePathWhitelisted', () => {
+  test('returns false if filePath is not listed in the globs', () => {
+    atom = { config: { get: jest.fn(() => []) } };
+
+    const actual = isFilePathWhitelisted('foo.js');
+    const expected = false;
+
+    expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.whitelistedGlobs');
+    expect(actual).toBe(expected);
+  });
+
+  test('returns true if filePath is not listed in the globs', () => {
+    atom = { config: { get: jest.fn(() => ['*.js']) } };
+
+    const actual = isFilePathWhitelisted('foo.js');
+    const expected = true;
+
+    expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.whitelistedGlobs');
     expect(actual).toBe(expected);
   });
 });


### PR DESCRIPTION
Whitelist globs will take precedence over any scopes and excluded globs. For more information on how
globs are matched, see the documentation at https://github.com/isaacs/minimatch. We are not using
any special options from the minimatch library.

Closes #62