### PR TITLE
docs(package): clarify description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prettier-atom",
   "main": "./dist/main.js",
   "version": "0.22.0",
-  "description": "Atom plugin for formatting JavaScript using Prettier-ESlint",
+  "description": "Atom plugin for formatting JavaScript using prettier with (optional) prettier-eslint integration",
   "keywords": [
     "atom",
     "javascript",


### PR DESCRIPTION
Just to make sure it's clear that prettier-eslint is optional.