### PR TITLE
feat(whitelist): force whitelist if provided

### DIFF
--- a/dist/config-schema.json
+++ b/dist/config-schema.json
@@ -59,7 +59,7 @@
       },
       "whitelistedGlobs": {
         "title": "Include (list of globs)",
-        "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob.",
+        "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob. NOTE: If there are globs in this list, files not matching the globs will not be formatted on save regardless of other options.",
         "type": "array",
         "default": [],
         "order": 5

--- a/dist/formatOnSave.js
+++ b/dist/formatOnSave.js
@@ -12,12 +12,17 @@ var _require2 = require('./helpers'),
     isFilePathEslintignored = _require2.isFilePathEslintignored,
     isFilePathExcluded = _require2.isFilePathExcluded,
     isInScope = _require2.isInScope,
-    isFilePathWhitelisted = _require2.isFilePathWhitelisted;
+    isFilePathWhitelisted = _require2.isFilePathWhitelisted,
+    isWhitelistProvided = _require2.isWhitelistProvided;
 
 var formatOnSaveIfAppropriate = function formatOnSaveIfAppropriate(editor) {
+  if (!isFormatOnSaveEnabled()) return;
+
   var filePath = getCurrentFilePath(editor);
 
-  if (!isFormatOnSaveEnabled()) return;
+  if (filePath && isWhitelistProvided() && !isFilePathWhitelisted(filePath)) {
+    return;
+  }
 
   if (filePath && !isFilePathWhitelisted(filePath)) {
     if (!isInScope(editor)) return;

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -125,6 +125,10 @@ var isFilePathWhitelisted = function isFilePathWhitelisted(filePath) {
   return someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.whitelistedGlobs'), filePath);
 };
 
+var isWhitelistProvided = function isWhitelistProvided() {
+  return getConfigOption('formatOnSaveOptions.whitelistedGlobs').length > 0;
+};
+
 var getPrettierOptions = function getPrettierOptions(editor) {
   return {
     printWidth: getPrettierOption('printWidth'),
@@ -147,6 +151,7 @@ module.exports = {
   isFilePathEslintignored: isFilePathEslintignored,
   isFilePathExcluded: isFilePathExcluded,
   isFilePathWhitelisted: isFilePathWhitelisted,
+  isWhitelistProvided: isWhitelistProvided,
   isFormatOnSaveEnabled: isFormatOnSaveEnabled,
   isLinterEslintAutofixEnabled: isLinterEslintAutofixEnabled,
   shouldUseEslint: shouldUseEslint,

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -59,7 +59,7 @@
       },
       "whitelistedGlobs": {
         "title": "Include (list of globs)",
-        "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob.",
+        "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob. NOTE: If there are globs in this list, files not matching the globs will not be formatted on save regardless of other options.",
         "type": "array",
         "default": [],
         "order": 5

--- a/src/formatOnSave.js
+++ b/src/formatOnSave.js
@@ -9,12 +9,17 @@ const {
   isFilePathExcluded,
   isInScope,
   isFilePathWhitelisted,
+  isWhitelistProvided,
 } = require('./helpers');
 
 const formatOnSaveIfAppropriate = (editor: TextEditor) => {
+  if (!isFormatOnSaveEnabled()) return;
+
   const filePath = getCurrentFilePath(editor);
 
-  if (!isFormatOnSaveEnabled()) return;
+  if (filePath && isWhitelistProvided() && !isFilePathWhitelisted(filePath)) {
+    return;
+  }
 
   if (filePath && !isFilePathWhitelisted(filePath)) {
     if (!isInScope(editor)) return;

--- a/src/formatOnSave.test.js
+++ b/src/formatOnSave.test.js
@@ -38,6 +38,8 @@ test('it executes prettier on buffer range', () => {
 
 test('it executes prettier on buffer range if file is whitelisted regardless of exclusions or scopes', () => {
   // $FlowFixMe
+  helpers.isWhitelistProvided.mockImplementation(() => true);
+  // $FlowFixMe
   helpers.isInScope.mockImplementation(() => false);
   // $FlowFixMe
   helpers.isFilePathExcluded.mockImplementation(() => true);
@@ -47,6 +49,21 @@ test('it executes prettier on buffer range if file is whitelisted regardless of 
   formatOnSave(editor, filePathFixture);
 
   expect(executePrettierOnBufferRange).toHaveBeenCalledWith(editor, rangeFixture);
+});
+
+test('it does not execute prettier if whitelist is provided and file is not whitelisted', () => {
+  // $FlowFixMe
+  helpers.isWhitelistProvided.mockImplementation(() => true);
+  // $FlowFixMe
+  helpers.isInScope.mockImplementation(() => true);
+  // $FlowFixMe
+  helpers.isFilePathExcluded.mockImplementation(() => false);
+  // $FlowFixMe
+  helpers.isFilePathWhitelisted.mockImplementation(() => false);
+
+  formatOnSave(editor, filePathFixture);
+
+  expect(executePrettierOnBufferRange).toHaveBeenCalledTimes(0);
 });
 
 test('it executes prettier on embedded scripts if scope is an embedded scope', () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -87,6 +87,8 @@ const isFilePathExcluded = (filePath: FilePath) =>
 const isFilePathWhitelisted = (filePath: FilePath) =>
   someGlobsMatchFilePath(getConfigOption('formatOnSaveOptions.whitelistedGlobs'), filePath);
 
+const isWhitelistProvided = () => getConfigOption('formatOnSaveOptions.whitelistedGlobs').length > 0;
+
 const getPrettierOptions = (editor: TextEditor) => ({
   printWidth: getPrettierOption('printWidth'),
   tabWidth: useAtomTabLengthIfAuto(editor, getPrettierOption('tabWidth')),
@@ -107,6 +109,7 @@ module.exports = {
   isFilePathEslintignored,
   isFilePathExcluded,
   isFilePathWhitelisted,
+  isWhitelistProvided,
   isFormatOnSaveEnabled,
   isLinterEslintAutofixEnabled,
   shouldUseEslint,

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -12,6 +12,7 @@ const {
   isFilePathEslintignored,
   isFilePathExcluded,
   isFilePathWhitelisted,
+  isWhitelistProvided,
   isCurrentScopeEmbeddedScope,
   isLinterEslintAutofixEnabled,
   shouldUseEslint,
@@ -226,6 +227,24 @@ describe('isFilePathWhitelisted', () => {
     const actual = isFilePathWhitelisted('foo.js');
     const expected = true;
 
+    expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.whitelistedGlobs');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('isWhitelistProvided', () => {
+  test('returns true if there are whitelist items provided', () => {
+    atom = { config: { get: jest.fn(() => ['*.js']) } };
+    const actual = isWhitelistProvided();
+    const expected = true;
+    expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.whitelistedGlobs');
+    expect(actual).toBe(expected);
+  });
+
+  test('returns false if the whitelist is empty', () => {
+    atom = { config: { get: jest.fn(() => []) } };
+    const actual = isWhitelistProvided();
+    const expected = false;
     expect(atom.config.get).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.whitelistedGlobs');
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
**What**: Update the logic of whitelist to be required if provided

**Why**: The use case of a whitelist is for people who have various projects on their machine. Some of them they are able to use `prettier-atom` on and others they are not. It's often easier to maintain a list of projects they're allowed to use `prettier-atom` on (whitelist) than it is to maintain a list of projects they are _not_ allowed to use `prettier-atom` on (blacklist). For these users, we say that if you do provide a whitelist, then the files _must_ match the whitelist or they will _not_ be formatted on save.

**How**:
- Add method `isWhitelistProvided` to `helpers`
- Add logic in `formatOnSaveIfAppropriate` for skipping if the whitelist is provided and the file is not whitelisted
- Add note in config schema about this behavior