### PR TITLE
fix(linter): refresh linter highlighting after format

### DIFF
--- a/decls/index.js
+++ b/decls/index.js
@@ -32,11 +32,22 @@ declare type TextEditor = {
     ) => void,
   ) => void,
 };
+declare type Atom$View = any;
+declare type Atom$Workspace = any;
+declare type Atom$Command = { name: string, displayName: string };
 declare var atom: {
+  commands: {
+    dispatch: (view: Atom$View, commandName: string) => void,
+    findCommands: ({ target: Atom$View }) => Array<Atom$Command>,
+  },
   config: {
     get: (key: string) => any,
   },
   notifications: {
     addError: (message: string, options?: { detail?: string, dismissable?: boolean }) => void,
   },
+  views: {
+    getView: (Atom$Workspace) => Atom$View,
+  },
+  workspace: Atom$Workspace,
 };

--- a/dist/executePrettier.js
+++ b/dist/executePrettier.js
@@ -10,7 +10,8 @@ var _require2 = require('./helpers'),
     getPrettierOptions = _require2.getPrettierOptions,
     getCurrentFilePath = _require2.getCurrentFilePath,
     shouldDisplayErrors = _require2.shouldDisplayErrors,
-    shouldUseEslint = _require2.shouldUseEslint;
+    shouldUseEslint = _require2.shouldUseEslint,
+    runLinter = _require2.runLinter;
 
 var EMBEDDED_JS_REGEX = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi;
 
@@ -48,6 +49,7 @@ var executePrettierOnBufferRange = function executePrettierOnBufferRange(editor,
 
   editor.setTextInBufferRange(bufferRange, transformed);
   editor.setCursorScreenPosition(cursorPositionPriorToFormat);
+  runLinter(editor);
 };
 
 var executePrettierOnEmbeddedScripts = function executePrettierOnEmbeddedScripts(editor) {

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -10,6 +10,7 @@ var path = require('path');
 // constants
 var LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;
 var EMBEDDED_SCOPES = ['text.html.vue', 'text.html.basic'];
+var LINTER_LINT_COMMAND = 'linter:lint';
 
 // local helpers
 var getCurrentScope = function getCurrentScope(editor) {
@@ -66,6 +67,12 @@ var getAtomTabLength = function getAtomTabLength(editor) {
 
 var useAtomTabLengthIfAuto = function useAtomTabLengthIfAuto(editor, tabLength) {
   return tabLength === 'auto' ? getAtomTabLength(editor) : Number(tabLength);
+};
+
+var isLinterLintCommandDefined = function isLinterLintCommandDefined(editor) {
+  return atom.commands.findCommands({ target: atom.views.getView(editor) }).some(function (command) {
+    return command.name === LINTER_LINT_COMMAND;
+  });
 };
 
 // public helpers
@@ -141,6 +148,10 @@ var getPrettierOptions = function getPrettierOptions(editor) {
   };
 };
 
+var runLinter = function runLinter(editor) {
+  return isLinterLintCommandDefined(editor) ? atom.commands.dispatch(atom.views.getView(editor), LINTER_LINT_COMMAND) : undefined;
+};
+
 module.exports = {
   getConfigOption: getConfigOption,
   shouldDisplayErrors: shouldDisplayErrors,
@@ -156,5 +167,6 @@ module.exports = {
   isLinterEslintAutofixEnabled: isLinterEslintAutofixEnabled,
   shouldUseEslint: shouldUseEslint,
   shouldRespectEslintignore: shouldRespectEslintignore,
-  getPrettierOptions: getPrettierOptions
+  getPrettierOptions: getPrettierOptions,
+  runLinter: runLinter
 };

--- a/src/executePrettier.js
+++ b/src/executePrettier.js
@@ -3,7 +3,13 @@ const prettierEslint = require('prettier-eslint');
 const prettier = require('prettier');
 const { allowUnsafeNewFunction } = require('loophole');
 
-const { getPrettierOptions, getCurrentFilePath, shouldDisplayErrors, shouldUseEslint } = require('./helpers');
+const {
+  getPrettierOptions,
+  getCurrentFilePath,
+  shouldDisplayErrors,
+  shouldUseEslint,
+  runLinter,
+} = require('./helpers');
 
 const EMBEDDED_JS_REGEX = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi;
 
@@ -39,6 +45,7 @@ const executePrettierOnBufferRange = (editor: TextEditor, bufferRange: Range) =>
 
   editor.setTextInBufferRange(bufferRange, transformed);
   editor.setCursorScreenPosition(cursorPositionPriorToFormat);
+  runLinter(editor);
 };
 
 const executePrettierOnEmbeddedScripts = (editor: TextEditor) =>

--- a/src/executePrettier.test.js
+++ b/src/executePrettier.test.js
@@ -43,6 +43,12 @@ describe('executePrettierOnBufferRange()', () => {
     expect(editor.setCursorScreenPosition).toHaveBeenCalledWith(startCursorScreenPosition);
   });
 
+  test('runs linter:lint if available to refresh linter highlighting', () => {
+    executePrettierOnBufferRange(editor, bufferRangeFixture);
+
+    expect(helpers.runLinter).toHaveBeenCalled();
+  });
+
   test('transforms the given buffer range using prettier-eslint if config enables it', () => {
     // $FlowFixMe
     helpers.shouldUseEslint.mockImplementation(() => true);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,6 +7,7 @@ const path = require('path');
 // constants
 const LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;
 const EMBEDDED_SCOPES = ['text.html.vue', 'text.html.basic'];
+const LINTER_LINT_COMMAND = 'linter:lint';
 
 // local helpers
 const getCurrentScope = (editor: TextEditor) => editor.getGrammar().scopeName;
@@ -47,6 +48,11 @@ const getAtomTabLength = (editor: TextEditor) =>
 
 const useAtomTabLengthIfAuto = (editor, tabLength) =>
   tabLength === 'auto' ? getAtomTabLength(editor) : Number(tabLength);
+
+const isLinterLintCommandDefined = (editor: TextEditor) =>
+  atom.commands
+    .findCommands({ target: atom.views.getView(editor) })
+    .some(command => command.name === LINTER_LINT_COMMAND);
 
 // public helpers
 const getConfigOption = (key: string) => atom.config.get(`prettier-atom.${key}`);
@@ -99,6 +105,11 @@ const getPrettierOptions = (editor: TextEditor) => ({
   jsxBracketSameLine: getPrettierOption('jsxBracketSameLine'),
 });
 
+const runLinter = (editor: TextEditor) =>
+  isLinterLintCommandDefined(editor)
+    ? atom.commands.dispatch(atom.views.getView(editor), LINTER_LINT_COMMAND)
+    : undefined;
+
 module.exports = {
   getConfigOption,
   shouldDisplayErrors,
@@ -115,4 +126,5 @@ module.exports = {
   shouldUseEslint,
   shouldRespectEslintignore,
   getPrettierOptions,
+  runLinter,
 };

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -17,6 +17,7 @@ const {
   isLinterEslintAutofixEnabled,
   shouldUseEslint,
   getPrettierOptions,
+  runLinter,
 } = require('./helpers');
 
 jest.mock('atom-linter');
@@ -308,5 +309,37 @@ describe('getPrettierOptions', () => {
     const expected = 8;
 
     expect(actual).toEqual(expected);
+  });
+});
+
+describe('runLinter()', () => {
+  test('runs `linter:lint` command', () => {
+    const editor = textEditor();
+    const viewMock = { isViewMock: true };
+    const commandsMock = [{ name: 'linter:lint', displayName: 'Linter: Lint' }];
+    atom = {
+      commands: { dispatch: jest.fn(), findCommands: jest.fn(() => commandsMock) },
+      views: { getView: jest.fn(() => viewMock) },
+    };
+
+    runLinter(editor);
+
+    expect(atom.views.getView).toHaveBeenCalledWith(editor);
+    expect(atom.commands.dispatch).toHaveBeenCalledWith(viewMock, 'linter:lint');
+  });
+
+  test('does nothing if `linter:lint` command does not exist', () => {
+    const editor = textEditor();
+    const viewMock = { isViewMock: true };
+    const commandsMock = [];
+    atom = {
+      commands: { dispatch: jest.fn(), findCommands: jest.fn(() => commandsMock) },
+      views: { getView: jest.fn(() => viewMock) },
+    };
+
+    runLinter(editor);
+
+    expect(atom.commands.findCommands).toHaveBeenCalledWith({ target: viewMock });
+    expect(atom.commands.dispatch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Formatting seemed to cause linter highlighting to disappear. Now, if we detect that the
`linter:lint` command exists, we invoke it after formatting so that the highlighting will reappear.

Fixes #86